### PR TITLE
[FIX] Missing trial_types are not added to a model specification / fixes #197

### DIFF
--- a/src/subject_level/convertOnsetTsvToMat.m
+++ b/src/subject_level/convertOnsetTsvToMat.m
@@ -2,27 +2,23 @@
 
 function fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
   %
-  % Short description of what the function does goes here.
+  % Converts an  events.tsv file to an onset file suitable for SPM subject level
+  % analysis.
+  % The scripts extracts the trial type, onsets, and durations, and
+  % converts them and stores them in a mat file.
   %
   % USAGE::
   %
-  %   [argout1, argout2] = templateFunction(argin1, [argin2 == default,] [argin3])
+  %   fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
   %
-  % :param argin1: (dimension) obligatory argument. Lorem ipsum dolor sit amet,
-  %                consectetur adipiscing elit. Ut congue nec est ac lacinia.
-  % :type argin1: type
-  % :param argin2: optional argument and its default value. And some of the
-  %               options can be shown in litteral like ``this`` or ``that``.
-  % :type argin2: string
-  % :param argin3: (dimension) optional argument
+  % :param opt:
+  % :type opt: structure
+  % :param tsvFile:
+  % :type tsvFile: string
   %
-  % :returns: - :argout1: (type) (dimension)
-  %           - :argout2: (type) (dimension)
+  % :returns: - :fullpathOnsetFileName: (string) name of the output `.mat` file.
   %
-  % Converts a tsv file to an onset file suitable for SPM ffx analysis
-  % The scripts extracts the conditions' names, onsets, and durations, and
-  % converts them to TRs (time unit) and saves the onset file to be used for
-  % SPM
+
   %
   [pth, file, ext] = spm_fileparts(tsvFile);
   tsvFile = validationInputFile(pth, [file, ext]);
@@ -58,7 +54,7 @@ function fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
   end
 
   isTrialType = strfind(step.Model.X, 'trial_type.');
-  
+
   % create empty cell to be filled in according to the conditions present in each run
   names = {};
   onsets = {};
@@ -78,12 +74,14 @@ function fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
       idx = find(strcmp(conditionName, conds));
 
       if ~isempty(idx)
-      % Get the onset and duration of each condition
-      names{1, end+1} = conditionName;
-      onsets{1, end+1} = t.onset(idx)'; %#ok<*AGROW,*NASGU>
-      durations{1, end+1} = t.duration(idx)';
+        % Get the onset and duration of each condition
+        names{1, end + 1} = conditionName;
+        onsets{1, end + 1} = t.onset(idx)'; %#ok<*AGROW,*NASGU>
+        durations{1, end + 1} = t.duration(idx)';
+      else
+        warning('No trial found for trial type %s in \n%s', conditionName, tsvFile);
       end
-      
+
     end
   end
 

--- a/src/subject_level/convertOnsetTsvToMat.m
+++ b/src/subject_level/convertOnsetTsvToMat.m
@@ -58,6 +58,11 @@ function fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
   end
 
   isTrialType = strfind(step.Model.X, 'trial_type.');
+  
+  % create empty cell to be filled in according to the conditions present in each run
+  names = {};
+  onsets = {};
+  durations = {};
 
   % for each condition
   for iCond = 1:numel(isTrialType)
@@ -72,11 +77,13 @@ function fullpathOnsetFileName = convertOnsetTsvToMat(opt, tsvFile)
       % each line in the tsv files
       idx = find(strcmp(conditionName, conds));
 
+      if ~isempty(idx)
       % Get the onset and duration of each condition
-      names{1, iCond} = conditionName;
-      onsets{1, iCond} = t.onset(idx)'; %#ok<*AGROW,*NASGU>
-      durations{1, iCond} = t.duration(idx)';
-
+      names{1, end+1} = conditionName;
+      onsets{1, end+1} = t.onset(idx)'; %#ok<*AGROW,*NASGU>
+      durations{1, end+1} = t.duration(idx)';
+      end
+      
     end
   end
 

--- a/src/subject_level/createAndReturnOnsetFile.m
+++ b/src/subject_level/createAndReturnOnsetFile.m
@@ -2,28 +2,27 @@
 
 function onsetFileName = createAndReturnOnsetFile(opt, subID, tsvFile, funcFWHM)
   %
-  % Short description of what the function does goes here.
+  % For a given events.tsv file it creates a .mat file that can directly be used
+  % for the GLM specification of a subject level model. The file is moved
+  % directly into the folder of the GLM.
   %
   % USAGE::
   %
-  %   [argout1, argout2] = templateFunction(argin1, [argin2 == default,] [argin3])
+  %   onsetFileName = createAndReturnOnsetFile(opt, subID, tsvFile, funcFWHM)
   %
-  % :param argin1: (dimension) obligatory argument. Lorem ipsum dolor sit amet,
-  %                consectetur adipiscing elit. Ut congue nec est ac lacinia.
-  % :type argin1: type
-  % :param argin2: optional argument and its default value. And some of the
-  %               options can be shown in litteral like ``this`` or ``that``.
-  % :type argin2: string
-  % :param argin3: (dimension) optional argument
+  % :param opt:
+  % :type opt: structure
+  % :param subID:
+  % :type subID: string
+  % :param tsvFile: fullpath name of the tsv file.
+  % :type tsvFile: string
+  % :param funcFWHM: size of the FWHM gaussian kernel used to the subject level
+  %                  GLM. Necessary for the GLM directory.
+  % :type funcFWHM: float
   %
-  % :returns: - :argout1: (type) (dimension)
-  %           - :argout2: (type) (dimension)
+  % :returns: - :onsetFileName: (string) fullpath name of the file created.
+  %                             Removes any prefix.
   %
-  % onsetFileName = createAndReturnOnsetFile(opt, boldFileName, prefix, isMVPA)
-  %
-  % gets the tsv onset file based on the bold file name (removes any prefix)
-  %
-  % convert the tsv files to a mat file to be used by SPM
 
   onsetFileName = convertOnsetTsvToMat(opt, tsvFile);
 

--- a/tests/dummyData/models/model-vislocalizer_smdl.json
+++ b/tests/dummyData/models/model-vislocalizer_smdl.json
@@ -9,7 +9,7 @@
       "Level": "run",
       "Model": {
         "X": [
-          "trial_type.VisMot", "trial_type.VisStat",
+          "trial_type.VisMot", "trial_type.VisStat", "trial_type.missing_condition",
           "trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z"
         ]
       },


### PR DESCRIPTION
fix #197, this way the .mat files contains only the `trial_type` entries that are present in the `events` file. This way if eg responses are missing, they will not be put in the model.

(I have created this pr from the submodule of my analysis repo, it is the first so let me know if this way is correct)