### PR TITLE
[FIX] fix typo

### DIFF
--- a/src/workflows/bidsFFX.m
+++ b/src/workflows/bidsFFX.m
@@ -79,7 +79,7 @@ function bidsFFX(action, opt, funcFWHM)
 
           deleteResidualImages(getFFXdir(subID, funcFWHM, opt));
 
-          movefile(['sub-', subID, '_task-', opt.taskName, 'design_*'], ...
+          movefile(['sub-', subID, '_task-', opt.taskName, '_design_*'], ...
                    getFFXdir(subID, funcFWHM, opt));
 
         case 'contrasts'


### PR DESCRIPTION
in `bidsFFX` it wants to move a `.png` but due to a typo it was crashing: 

```
/bin/bash: fslmerge: command not found
Error using movefile
mv: rename
/Users/battal/Cerens_files/fMRI/Processed/RhythmCateg/Pilots/RhythmBlock/code/rhythmBlock_fMRI_analysis/src/sub-008_task-RhythmBlockdesign_*
to
/Users/battal/Cerens_files/fMRI/Processed/RhythmCateg/Pilots/RhythmBlock/derivatives/cpp_spm/sub-008/stats/ffx_task-RhythmBlock/ffx_space-individual_FWHM-3/sub-008_task-RhythmBlockdesign_*:
No such file or directory

Error in bidsFFX (line 82)
          movefile(['sub-', subID, '_task-', opt.taskName, 'design_*'], ...
```
 