### PR TITLE
[FIX] argument order of bidsFFX

### DIFF
--- a/demos/vismotion/batch.m
+++ b/demos/vismotion/batch.m
@@ -39,7 +39,7 @@ bidsFFX('contrasts', opt, funcFWHM);
 
 % group level univariate
 conFWHM = 6;
-bidsRFX('smoothContrasts', funcFWHM, conFWHM, opt);
+bidsRFX('smoothContrasts', opt, funcFWHM, conFWHM);
 
 % Not implemented yet
 % bidsRFX(action, opt, funcFWHM, conFWHM);


### PR DESCRIPTION
the argument order of bidsRFX is corrected. otherwise it was mixing the opt with smoothing width. It was only on `demos/vismotion`