### PR TITLE
[FIX] bidsCopy does not delete previously copied tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,11 @@ demos/spm*/source
 tests/sub-01/*
 tests/group/*
 tests/models/*.json
-tests/dummyData/derivatives/cpp_spm/sub-*/*/*/*.nii
+tests/dummyData/derivatives/cpp_spm/sub-*/*/*/*.nii*
 tests/dummyData/derivatives/cpp_spm/sub-*/*/*/*.tsv
 tests/dummyData/derivatives/cpp_spm/sub-*/*/*/*.txt
 tests/dummyData/derivatives/cpp_spm/sub-*/*/*/*.json
-tests/dummyData/derivatives/cpp_spm/sub-*/stats/*/*/*.nii
+tests/dummyData/derivatives/cpp_spm/sub-*/stats/*/*/*.nii*
 
 # ignore content of the build folder of the doc
 docs/build/*

--- a/tests/createDummyDataSet.sh
+++ b/tests/createDummyDataSet.sh
@@ -25,7 +25,7 @@ do
 			ThisDir=$StartDir/sub-$Subject/ses-$Ses/func
 			mkdir $ThisDir
 
-			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.nii.gz
+			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.nii
 			echo "{\"TaskName\": \"vislocalizer\"}" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.json
 			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_bold.nii
 			echo "{\"TaskName\": \"vislocalizer\"}" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_bold.json

--- a/tests/createDummyDataSet.sh
+++ b/tests/createDummyDataSet.sh
@@ -25,8 +25,10 @@ do
 			ThisDir=$StartDir/sub-$Subject/ses-$Ses/func
 			mkdir $ThisDir
 
-			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.nii
+			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.nii.gz
+			echo "{\"TaskName\": \"vislocalizer\"}" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.json
 			touch $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_bold.nii
+			echo "{\"TaskName\": \"vislocalizer\"}" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_bold.json
 			touch $ThisDir/asub-$Subject\_ses-$Ses\_task-vismotion_run-1_bold.nii
 			touch $ThisDir/asub-$Subject\_ses-$Ses\_task-vismotion_run-2_bold.nii
 
@@ -40,15 +42,15 @@ do
 			touch $ThisDir/s6wusub-$Subject\_ses-$Ses\_task-vislocalizer_bold.nii
 			touch $ThisDir/rp_sub-$Subject\_ses-$Ses\_task-vislocalizer_bold.txt
 
-			echo "onset\tduration\ttrial_type" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vislocalizer_events.tsv
+			echo "onset\tduration\ttrial_type" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vislocalizer_events.tsv
 			echo "2\t15\tVisMot" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vislocalizer_events.tsv
 			echo "25\t15\tVisStat" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vislocalizer_events.tsv
 
-			echo "onset\tduration\ttrial_type" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_events.tsv
+			echo "onset\tduration\ttrial_type" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_events.tsv
 			echo "2\t2\tVisMotUp" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_events.tsv
 			echo "4\t2\tVisMotDown" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-1_events.tsv
 
-			echo "onset\tduration\ttrial_type" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_events.tsv
+			echo "onset\tduration\ttrial_type" > $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_events.tsv
 			echo "3\t2\tVisMotDown" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_events.tsv
 			echo "6\t2\tVisMotUp" >> $ThisDir/sub-$Subject\_ses-$Ses\_task-vismotion_run-2_events.tsv
 

--- a/tests/test_bidsCopyRawFolder.m
+++ b/tests/test_bidsCopyRawFolder.m
@@ -18,6 +18,9 @@ function test_bidsCopyRawFolderBasic()
 
   bidsCopyRawFolder(opt, 1);
 
+  layoutRaw = bids.layout(opt.dataDir);
+  layoutDerivatives = bids.layout(fullfile(opt.dataDir, '..', 'derivatives', 'cpp_spm'));
+
   assertEqual(exist( ...
                     fullfile(opt.dataDir, '..', ...
                              'derivatives', 'cpp_spm', ...
@@ -53,10 +56,20 @@ function test_bidsCopyRawFolder2tasks()
 
   opt = checkOptions(opt);
 
-  bidsCopyRawFolder(opt, 1, {'func'});
+  unZip = false;
+  deleteZippedNii = false;
+  bidsCopyRawFolder(opt, deleteZippedNii, {'func'}, unZip);
+
+  assertEqual(exist( ...
+                    fullfile(opt.derivativesDir, 'derivatives', 'cpp_spm', ...
+                             'sub-01', ...
+                             'ses-01', ...
+                             'func', ...
+                             'sub-01_ses-01_task-vismotion_run-1_bold.json'), 'file'), ...
+              2);
 
   opt.taskName = 'vislocalizer';
-  bidsCopyRawFolder(opt, 1, {'func'});
+  bidsCopyRawFolder(opt, deleteZippedNii, {'func'}, unZip);
 
   BIDS = bids.layout(fullfile(opt.derivativesDir, 'derivatives', 'cpp_spm'));
 

--- a/tests/test_bidsCopyRawFolder.m
+++ b/tests/test_bidsCopyRawFolder.m
@@ -8,19 +8,13 @@ end
 
 function test_bidsCopyRawFolderBasic()
 
-  % TODO add test to only copy some modalities
-
-  % directory with this script becomes the current directory
   opt.dataDir = fullfile( ...
                          fileparts(mfilename('fullpath')), ...
                          '..', 'demos',  'MoAE', 'output', 'MoAEpilot');
 
-  % task to analyze
   opt.taskName = 'auditory';
 
   opt = checkOptions(opt);
-
-  checkDependencies();
 
   bidsCopyRawFolder(opt, 1);
 
@@ -41,4 +35,37 @@ function test_bidsCopyRawFolderBasic()
                              'derivatives', 'cpp_spm', 'sub-01', 'anat', ...
                              'sub-01_T1w.nii'), 'file'), ...
               2);
+end
+
+function test_bidsCopyRawFolder2tasks()
+
+  system('rm -Rf dummyData/copy');
+
+  opt.dataDir = fullfile( ...
+                         fileparts(mfilename('fullpath')), ...
+                         'dummyData', 'derivatives', 'cpp_spm');
+
+  opt.derivativesDir = fullfile( ...
+                                fileparts(mfilename('fullpath')), ...
+                                'dummyData', 'copy');
+
+  opt.taskName = 'vismotion';
+
+  opt = checkOptions(opt);
+
+  bidsCopyRawFolder(opt, 1, {'func'});
+
+  opt.taskName = 'vislocalizer';
+  bidsCopyRawFolder(opt, 1, {'func'});
+
+  BIDS = bids.layout(fullfile(opt.derivativesDir, 'derivatives', 'cpp_spm'));
+
+  modalities = bids.query(BIDS, 'modalities');
+  assertEqual(numel(modalities), 1);
+
+  tasks = bids.query(BIDS, 'tasks');
+  assertEqual(numel(tasks), 2);
+
+  system('rm -Rf dummyData/copy');
+
 end


### PR DESCRIPTION
fixes #276 

In theory, this should not delete files from the previous task when using the same derivative folder.