### PR TITLE
[FIX] adapted for looping through subjects

### DIFF
--- a/src/workflows/bidsConcatBetaTmaps.m
+++ b/src/workflows/bidsConcatBetaTmaps.m
@@ -57,10 +57,13 @@ function bidsConcatBetaTmaps(opt, funcFWHM, deleteIndBeta, deleteIndTmaps)
 
       % beta maps
       outputName = ['4D_beta_', num2str(funcFWHM), '.nii'];
+      
+      matlabbatch = [];
       matlabbatch = setBatch3Dto4D(matlabbatch, beta_maps, RT, outputName);
 
       % t-maps
       outputName = ['4D_t_maps_', num2str(funcFWHM), '.nii'];
+      
       matlabbatch = setBatch3Dto4D(matlabbatch, t_maps, RT, outputName);
 
       saveAndRunWorkflow(matlabbatch, 'concat_betaImg_tMaps', opt, subID);

--- a/src/workflows/bidsConcatBetaTmaps.m
+++ b/src/workflows/bidsConcatBetaTmaps.m
@@ -57,13 +57,13 @@ function bidsConcatBetaTmaps(opt, funcFWHM, deleteIndBeta, deleteIndTmaps)
 
       % beta maps
       outputName = ['4D_beta_', num2str(funcFWHM), '.nii'];
-      
+
       matlabbatch = [];
       matlabbatch = setBatch3Dto4D(matlabbatch, beta_maps, RT, outputName);
 
       % t-maps
       outputName = ['4D_t_maps_', num2str(funcFWHM), '.nii'];
-      
+
       matlabbatch = setBatch3Dto4D(matlabbatch, t_maps, RT, outputName);
 
       saveAndRunWorkflow(matlabbatch, 'concat_betaImg_tMaps', opt, subID);


### PR DESCRIPTION
when i use the concat script loop through different subjects due to the deletion option is on, matlabbatch gives an error. for every subject the clean matlabbatch should be opened. that's what this fix does. 