### PR TITLE
[ENH] add possibility to limit maximum number of volumes per run in a subject level GLM

### DIFF
--- a/src/batches/preproc/setBatchRealign.m
+++ b/src/batches/preproc/setBatchRealign.m
@@ -101,6 +101,8 @@ function [matlabbatch, voxDim] = setBatchRealign(varargin)
                         true);
         end
 
+        % TODO voxDim might be different for different tasks 
+        % could be important to keep track off for the normalization step later
         [voxDim, opt] = getFuncVoxelDims(opt, subFuncDataDir, boldFilename);
 
         file = fullfile(subFuncDataDir, boldFilename);
@@ -110,6 +112,10 @@ function [matlabbatch, voxDim] = setBatchRealign(varargin)
           % we reslice images that come from a previous batch
           % so we can return early
           case 'reslice'
+
+            % TODO voxDim might be different for different tasks 
+            % reslicing might change the voxel dimension for some tasks.
+
             spatial.realign.write.data(1) = ...
                 cfg_dep('Coregister: Estimate: Coregistered Images', ...
                         returnDependency(opt, 'coregister'), ...

--- a/src/subject_level/createAndReturnCounfoundMatFile.m
+++ b/src/subject_level/createAndReturnCounfoundMatFile.m
@@ -44,8 +44,13 @@ function counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFi
   names = intersect(X, names);
 
   R = [];
+  
   for col = 1:numel(names)
-    R(:, col) = content.(names{col});
+    if opt.glm.maxNbVols ~= Inf && numel(content.(names{col})) > opt.glm.maxNbVols
+        R(:, col) = content.(names{col})(1:opt.glm.maxNbVols);
+    else
+        R(:, col) = content.(names{col});
+    end
   end
 
   % save the confounds as a matfile

--- a/src/subject_level/createAndReturnCounfoundMatFile.m
+++ b/src/subject_level/createAndReturnCounfoundMatFile.m
@@ -44,12 +44,12 @@ function counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFi
   names = intersect(X, names);
 
   R = [];
-  
+
   for col = 1:numel(names)
     if opt.glm.maxNbVols ~= Inf && numel(content.(names{col})) > opt.glm.maxNbVols
-        R(:, col) = content.(names{col})(1:opt.glm.maxNbVols);
+      R(:, col) = content.(names{col})(1:opt.glm.maxNbVols);
     else
-        R(:, col) = content.(names{col});
+      R(:, col) = content.(names{col});
     end
   end
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ clean:
 
 data:
 	sh createDummyDataSet.sh
-	rm bids-examples/.gitkeep
+	rm -f bids-examples/.gitkeep
 	git clone git://github.com/bids-standard/bids-examples.git --depth 1
 	cp bids-examples/synthetic/dataset_description.json bids-examples/synthetic/derivatives/fmriprep
 

--- a/tests/tests_utils/test_createAndReturnCounfoundMatFile.m
+++ b/tests/tests_utils/test_createAndReturnCounfoundMatFile.m
@@ -10,6 +10,61 @@ end
 
 function test_createAndReturnCounfoundMatFile_basic()
 
+  [opt, subLabel, tsvFile] = setUp();
+
+  counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFile);
+
+  expectedFilename = fullfile(getDummyDataDir('stats'), 'sub-01', 'stats', ...
+                              'task-vislocalizer_space-MNI_FWHM-6', ...
+                              'sub-01_ses-01_task-vislocalizer_desc-confounds_regressors.mat');
+
+  assertEqual(exist(counfoundMatFile, 'file'), 2);
+  assertEqual(exist(expectedFilename, 'file'), 2);
+
+  expected_content = fullfile(getDummyDataDir(), 'mat_files', 'regressors.mat');
+
+  expected_R = load(expected_content, 'R');
+  actual_R = load(counfoundMatFile, 'R');
+  assertEqual(actual_R, expected_R);
+
+  expected_names = load(expected_content, 'names');
+  actual_names = load(counfoundMatFile, 'names');
+  assertEqual(actual_names, expected_names);
+
+  delete(counfoundMatFile);
+
+end
+
+function test_createAndReturnCounfoundMatFile_maxNbVols()
+
+  [opt, subLabel, tsvFile] = setUp();
+
+  opt.glm.maxNbVols = 50;
+
+  counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFile);
+
+  R = load(counfoundMatFile, 'R');
+
+  assertEqual(size(R.R, 1), opt.glm.maxNbVols);
+
+end
+
+function test_createAndReturnCounfoundMatFile_maxNbVols_gt_actualNbVols()
+
+  [opt, subLabel, tsvFile] = setUp();
+
+  opt.glm.maxNbVols = 400;
+
+  counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFile);
+
+  R = load(counfoundMatFile, 'R');
+
+  assertEqual(size(R.R, 1), 351);
+
+end
+
+function [opt, subLabel, tsvFile] = setUp()
+
   subLabel = '01';
   iSes = 1;
   iRun = 1;
@@ -30,24 +85,5 @@ function test_createAndReturnCounfoundMatFile_basic()
                  'suffix', 'regressors', ...
                  'extension', '.tsv');
   tsvFile = bids.query(BIDS, 'data', query);
-
-  counfoundMatFile = createAndReturnCounfoundMatFile(opt, subLabel, tsvFile);
-
-  expectedFilename = fullfile(getDummyDataDir('stats'), 'sub-01', 'stats', ...
-                              'task-vislocalizer_space-MNI_FWHM-6', ...
-                              'sub-01_ses-01_task-vislocalizer_desc-confounds_regressors.mat');
-
-  assertEqual(exist(counfoundMatFile, 'file'), 2);
-  assertEqual(exist(expectedFilename, 'file'), 2);
-
-  expected_content = fullfile(getDummyDataDir(), 'mat_files', 'regressors.mat');
-
-  expected_R = load(expected_content, 'R');
-  actual_R = load(counfoundMatFile, 'R');
-  assertEqual(actual_R, expected_R);
-
-  expected_names = load(expected_content, 'names');
-  actual_names = load(counfoundMatFile, 'names');
-  assertEqual(actual_names, expected_names);
 
 end


### PR DESCRIPTION
closes #220 

- [x] fixes issue that caused model specification to crash because of confounds regressors being longer than the number of timepoints 