### PR TITLE
[ENH] skullstripping fixes and options 

### DIFF
--- a/src/batches/preproc/setBatchSkullStripping.m
+++ b/src/batches/preproc/setBatchSkullStripping.m
@@ -37,6 +37,9 @@ function matlabbatch = setBatchSkullStripping(matlabbatch, BIDS, opt, subLabel)
   % It is also possible to segment a functional image by setting
   % ``opt.skullstrip.mean`` to ``true``
   %
+  % Skullstripping can be skipped by setting
+  % ``opt.skullstrip.do`` to ``false``
+  %
   % (C) Copyright 2020 CPP_SPM developers
 
   if ~opt.skullstrip.do
@@ -52,17 +55,15 @@ function matlabbatch = setBatchSkullStripping(matlabbatch, BIDS, opt, subLabel)
     [imageToSkullStrip, dataDir] = getMeanFuncFilename(BIDS, subLabel, opt);
   end
 
-  bf = bids.File(imageToSkullStrip);
-  bf.entities.space = 'individual';
-  bf.entities.desc = 'skullstripped';
-  output = bf.filename;
-
-  bf = bids.File(imageToSkullStrip);
-  bf.entities.space = 'individual';
-  bf.entities.label = 'brain';
-  bf.suffix = 'mask';
-
-  maskOutput = bf.filename;
+  bf = bids.File(imageToSkullStrip, 'use_schema', false);
+  if isSkullstripped(bf)
+    errorHandling(mfilename(), ...
+                  'imageAlreadySkullstripped', ...
+                  'The image is already skullstripped. Skipping skullstripping batch.', ...
+                  true, ...
+                  opt.verbosity);
+    return
+  end
 
   expression = sprintf('i1.*((i2+i3+i4)>%f)', opt.skullstrip.threshold);
 
@@ -123,13 +124,63 @@ function matlabbatch = setBatchSkullStripping(matlabbatch, BIDS, opt, subLabel)
 
   end
 
+  output = returnNameSkullstripOutput(imageToSkullStrip, 'image');
+  saveMetadataImage(dataDir, opt, output, imageToSkullStrip);
+
   matlabbatch = setBatchImageCalculation(matlabbatch, opt, input, output, dataDir, expression);
 
   %% Add a batch to output the mask
+  maskOutput = returnNameSkullstripOutput(imageToSkullStrip, 'mask');
+  saveMetadataImage(dataDir, opt, maskOutput, imageToSkullStrip);
+
   matlabbatch{end + 1} = matlabbatch{end};
   matlabbatch{end}.spm.util.imcalc.expression = sprintf( ...
                                                         '(i2+i3+i4)>%f', ...
                                                         opt.skullstrip.threshold);
   matlabbatch{end}.spm.util.imcalc.output = maskOutput;
 
+  %%
+  addSkullstrippedMetadataToRoot(BIDS);
+
+end
+
+function saveMetadataImage(dataDir, opt, output, imageToSkullStrip)
+
+  bf = bids.File(output);
+
+  json = bids.derivatives_json(output);
+
+  if strcmp(bf.suffix, 'mask')
+    json.content.Description = sprintf(['mask used for skullstripping values with', ...
+                                        '"p(GM) + p(WM) + p(CSF) > %f'], opt.skullstrip.threshold);
+
+  else
+    json.content.Description = sprintf(['image skullstripped for values with', ...
+                                        '"p(GM) + p(WM) + p(CSF) > %f'], opt.skullstrip.threshold);
+  end
+
+  json.content.Sources{1} = relPath(imageToSkullStrip);
+
+  % TODO RawSources
+  % will depend on if it is bold or not,
+  % if we are skullstripping a normalise)
+
+  if isfield(bf.entities, 'space') && strcmp(bf.entities.space, 'individual')
+    json.content.SpatialReference{1} = 'scanner space';
+  end
+
+  bids.util.jsonencode(fullfile(dataDir, json.filename), ...
+                       json.content);
+
+end
+
+function value = relPath(imageToSkullStrip)
+  bf = bids.File(imageToSkullStrip);
+  value = fullfile(bf.bids_path, bf.filename);
+end
+
+function addSkullstrippedMetadataToRoot(BIDS)
+  metadata = struct('SkullStripped', true);
+  filename = fullfile(BIDS.pth, 'desc-skullstripped.json');
+  bids.util.jsonencode(filename, metadata);
 end

--- a/src/batches/preproc/setBatchSkullStripping.m
+++ b/src/batches/preproc/setBatchSkullStripping.m
@@ -39,6 +39,10 @@ function matlabbatch = setBatchSkullStripping(matlabbatch, BIDS, opt, subLabel)
   %
   % (C) Copyright 2020 CPP_SPM developers
 
+  if ~opt.skullstrip.do
+    return
+  end
+
   printBatchName('skull stripping', opt);
 
   [imageToSkullStrip, dataDir] = getAnatFilename(BIDS, opt, subLabel);

--- a/src/bids/isSkullstripped.m
+++ b/src/bids/isSkullstripped.m
@@ -1,0 +1,28 @@
+function status = isSkullstripped(bidsFile)
+  %
+  % USAGE::
+  %
+  %   status = isSkullstripped(bidsFile)
+  %
+  % bidsFile is a bids.File object
+  %
+  % EXAMPLE
+  %
+  %     bf = bids.File('sub-01_T1w', 'use_schema', false);
+  %
+  %     status = isSkullstripped(bf)
+  %
+  %
+  % (C) Copyright 2022 CPP_SPM developers
+
+  status = false;
+
+  metadata = bidsFile.metadata;
+
+  if isfield(bidsFile.entities, 'desc') && strcmp(bidsFile.entities.desc, 'skullstripped')
+    status = true;
+  elseif ~isempty(metadata) && isfield(metadata, 'SkullStripped') &&  metadata.SkullStripped
+    status = true;
+  end
+
+end

--- a/src/bids/returnNameSkullstripOutput.m
+++ b/src/bids/returnNameSkullstripOutput.m
@@ -1,0 +1,28 @@
+function outputFilename = returnNameSkullstripOutput(inputFilename, outputType)
+  %
+  % (C) Copyright 2020 CPP_SPM developers
+
+  bf = bids.File(inputFilename, 'use_schema', false);
+  bf.entity_order();
+
+  bf.entities.space = 'individual';
+
+  if strcmp(outputType, 'image')
+    bf.entities.desc = 'skullstripped';
+  end
+
+  if strcmp(outputType, 'mask')
+    bf.entities.label = 'brain';
+    bf.suffix = 'mask';
+
+    if isfield(bf.entities, 'desc')
+      bf.entities.desc = '';
+    end
+
+  end
+
+  bf = bf.reorder_entities();
+
+  outputFilename = bf.filename;
+
+end

--- a/src/defaults/checkOptions.m
+++ b/src/defaults/checkOptions.m
@@ -309,6 +309,7 @@ function fieldsToSet = setDefaultOption()
   fieldsToSet.segment.samplingDistance = 3;
 
   %% Options for skullstripping
+  fieldsToSet.skullstrip.do = true;
   fieldsToSet.skullstrip.threshold = 0.75;
   fieldsToSet.skullstrip.mean = false;
 

--- a/src/defaults/checkOptions.m
+++ b/src/defaults/checkOptions.m
@@ -104,6 +104,8 @@ function opt = checkOptions(opt)
   %     - ``opt.skullstrip.threshold = 0.75`` - Threshold used for the skull stripping.
   %       Any voxel with ``p(grayMatter) +  p(whiteMatter) + p(CSF) > threshold``
   %       will be included in the mask.
+  %     - ``opt.skullstrip.do = true``  -  Set to ``true`` to skip skullstripping
+  %
   %
   %     - ``opt.stc.skip = false`` - boolean flag to skip slice time correction or not.
   %     - ``opt.stc.referenceSlice = []`` - reference slice for the slice timing correction.
@@ -117,7 +119,7 @@ function opt = checkOptions(opt)
   %
   %  - **preprocessing QA** (see ``functionalQA``)
   %
-  %     - ``opt.QA.func`` contains a lot of options used by ``spmup_first_level_qa``
+  %     ``opt.QA.func`` contains a lot of options used by ``spmup_first_level_qa``
   %
   %     - ``opt.QA.func.carpetPlot = true`` to plot carpet plot
   %     - ``opt.QA.func.MotionParameters = 'on'``

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -11,6 +11,8 @@ tmp
 dummyData/derivatives/cpp_spm-*/jobs
 dummyData/derivatives/cpp_spm-preproc/sub*
 
+dummyData/derivatives/cpp_spm-preproc/desc-skullstripped.json
+
 dummyData/derivatives/cpp_spm-stats/sub*
 dummyData/derivatives/cpp_spm-stats/derivatives
 dummyData/derivatives/cpp_spm-stats/README

--- a/tests/tests_batches/preproc/test_setBatchSkullStripping.m
+++ b/tests/tests_batches/preproc/test_setBatchSkullStripping.m
@@ -26,6 +26,21 @@ function test_setBatchSkullStripping_basic()
   assertEqual(matlabbatch{1}.spm.util.imcalc, expectedBatch{1}.spm.util.imcalc);
   assertEqual(matlabbatch{end}.spm.util.imcalc, expectedBatch{end}.spm.util.imcalc);
 
+  assertEqual(exist(fullfile(BIDS.pth, 'desc-skullstripped.json'), 'file'), 2);
+  delete(fullfile(BIDS.pth, 'desc-skullstripped.json'));
+
+  assertEqual(exist(fullfile(BIDS.pth, 'sub-01', 'ses-01', 'anat', ...
+                             'sub-01_ses-01_space-individual_desc-skullstripped_T1w.json'), ...
+                    'file'), 2);
+  delete(fullfile(BIDS.pth, 'sub-01', 'ses-01', 'anat', ...
+                  'sub-01_ses-01_space-individual_desc-skullstripped_T1w.json'));
+
+  assertEqual(exist(fullfile(BIDS.pth, 'sub-01', 'ses-01', 'anat', ...
+                             'sub-01_ses-01_space-individual_label-brain_mask.json'), ...
+                    'file'), 2);
+  delete(fullfile(BIDS.pth, 'sub-01', 'ses-01', 'anat', ...
+                  'sub-01_ses-01_space-individual_label-brain_mask.json'));
+
 end
 
 function test_setBatchSkullStripping_skip_skullstrip()

--- a/tests/tests_batches/preproc/test_setBatchSkullStripping.m
+++ b/tests/tests_batches/preproc/test_setBatchSkullStripping.m
@@ -28,6 +28,23 @@ function test_setBatchSkullStripping_basic()
 
 end
 
+function test_setBatchSkullStripping_skip_skullstrip()
+
+  subLabel = '01';
+
+  opt = setOptions('vislocalizer', subLabel);
+
+  opt.skullstrip.do = false;
+
+  BIDS = struct([]);
+
+  matlabbatch = {};
+  matlabbatch = setBatchSkullStripping(matlabbatch, BIDS, opt, subLabel);
+
+  assert(isempty(matlabbatch));
+
+end
+
 function expectedBatch = returnExpectedBatch(opt)
 
   expectedAnatDataDir = fullfile(getDummyDataDir('preproc'), 'sub-01', 'ses-01', 'anat');

--- a/tests/tests_bids/test_isSkullstripped.m
+++ b/tests/tests_bids/test_isSkullstripped.m
@@ -1,0 +1,40 @@
+% (C) Copyright 2022 CPP_SPM developers
+
+function test_suite = test_isSkullstripped %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+end
+
+function test_isSkullstripped_basic()
+
+  bf = bids.File('sub-01_T1w', 'use_schema', false);
+
+  status = isSkullstripped(bf);
+
+  assert(~status);
+
+end
+
+function test_isSkullstripped_entity()
+
+  bf = bids.File('sub-01_desc-skullstripped_T1w', 'use_schema', false);
+
+  status = isSkullstripped(bf);
+
+  assert(status);
+
+end
+
+function test_isSkullstripped_metadata()
+
+  bf = bids.File('sub-01_T1w', 'use_schema', false);
+  bf.metadata.SkullStripped = true;
+
+  status = isSkullstripped(bf);
+
+  assert(status);
+
+end

--- a/tests/tests_bids/test_returnNameSkullstripOutput.m
+++ b/tests/tests_bids/test_returnNameSkullstripOutput.m
@@ -1,0 +1,33 @@
+% (C) Copyright 2022 CPP_SPM developers
+
+function test_suite = test_returnNameSkullstripOutput %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+end
+
+function test_returnNameSkullstripOutput_basic()
+
+  inputFile = 'sub-001_T1w.nii';
+
+  image = returnNameSkullstripOutput(inputFile, 'image');
+  assertEqual(image, 'sub-001_space-individual_desc-skullstripped_T1w.nii');
+
+  mask = returnNameSkullstripOutput(inputFile, 'mask');
+  assertEqual(mask, 'sub-001_space-individual_label-brain_mask.nii');
+
+end
+
+function test_returnNameSkullstripOutput_oops()
+
+  inputFile = 'sub-001_acq-r0p375_desc-skullstripped_UNIT1.nii';
+
+  image = returnNameSkullstripOutput(inputFile, 'image');
+  assertEqual(image, 'sub-001_acq-r0p375_space-individual_desc-skullstripped_UNIT1.nii');
+
+  mask = returnNameSkullstripOutput(inputFile, 'mask');
+  assertEqual(mask, 'sub-001_acq-r0p375_space-individual_label-brain_mask.nii');
+
+end

--- a/tests/utils/defaultOptions.m
+++ b/tests/utils/defaultOptions.m
@@ -56,6 +56,7 @@ function expectedOptions = defaultOptions(taskName)
 
   expectedOptions.segment.samplingDistance = 3;
 
+  expectedOptions.skullstrip.do = true;
   expectedOptions.skullstrip.threshold = 0.75;
   expectedOptions.skullstrip.mean = false;
 


### PR DESCRIPTION
- [x] Properly ordering entities of output images ; fixes #550 
- [x] skip skullstrip if input image is skullstripped already
- [x]  implement a option `opt.skullstrip.do`
- [x] add metadata to root of the folder