### PR TITLE
[FIX] make GLM path more consistent

### DIFF
--- a/src/subject_level/getFFXdir.m
+++ b/src/subject_level/getFFXdir.m
@@ -26,7 +26,7 @@ function ffxDir = getFFXdir(subLabel, opt)
 
   nodeNameLabel = regexprep(nodeName, '[ -_]', '');
   if ~isempty(nodeNameLabel) && ~ismember(nodeNameLabel, {'runlevel', 'run'})
-    glmDirName = [glmDirName, '_desc-', bids.internal.camel_case(nodeName)];
+    glmDirName = [glmDirName, '_node-', bids.internal.camel_case(nodeName)];
   end
 
   ffxDir = fullfile(opt.dir.stats, ...

--- a/src/subject_level/getFFXdir.m
+++ b/src/subject_level/getFFXdir.m
@@ -24,7 +24,8 @@ function ffxDir = getFFXdir(subLabel, opt)
   rootNode = opt.model.bm.getRootNode();
   nodeName = rootNode.Name;
 
-  if ~isempty(nodeName) && ~strcmpi(nodeName, 'run_level')
+  nodeNameLabel = regexprep(nodeName, '[ -_]', '');
+  if ~isempty(nodeNameLabel) && ~ismember(nodeNameLabel, {'runlevel', 'run'})
     glmDirName = [glmDirName, '_desc-', bids.internal.camel_case(nodeName)];
   end
 

--- a/tests/createDummyDataSet.sh
+++ b/tests/createDummyDataSet.sh
@@ -335,7 +335,7 @@ for subject in ${subject_list}; do
 	# different model for model comparison
 	task_list='vismotion vislocalizer'
 	for task in ${task_list}; do
-		this_dir=${stats_dir}/sub-${subject}/task-${task}_space-IXI549Space_FWHM-6_desc-globalSignal
+		this_dir=${stats_dir}/sub-${subject}/task-${task}_space-IXI549Space_FWHM-6_node-globalSignal
 		mkdir -p ${this_dir}
 
 		cp dummyData/mat_files/SPM.mat ${this_dir}/SPM.mat

--- a/tests/tests_bids_model/test_getFFXdir.m
+++ b/tests/tests_bids_model/test_getFFXdir.m
@@ -8,6 +8,39 @@ function test_suite = test_getFFXdir %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_getFFXdir_ignored_desc()
+
+  subLabel = '01';
+
+  opt = setOptions('vislocalizer', subLabel, 'pipelineType', 'stats');
+
+  opt.fwhm.func = 0;
+
+  omitList = {'run'; ...
+              'run level'; ...
+              ' run level '; ...
+              '-run-level-'; ...
+              '_run_level_'};
+  omitList = cat(1, omitList, upper(omitList));
+
+  for i = 1:numel(omitList)
+
+    opt.model.bm.Nodes{1}.Name = omitList{i};
+    opt.model.bm.Edges{1}.Source = omitList{i};
+
+    ffxDir = getFFXdir(subLabel, opt);
+
+    expectedOutput = fullfile(getDummyDataDir('stats'), 'sub-01', ...
+                              'task-vislocalizer_space-IXI549Space_FWHM-0');
+
+    assertEqual(ffxDir, expectedOutput);
+    assertEqual(exist(expectedOutput, 'dir'), 7);
+
+    rmdir(ffxDir, 's');
+  end
+
+end
+
 function test_getFFXdir_basic()
 
   subLabel = '01';
@@ -21,7 +54,10 @@ function test_getFFXdir_basic()
 
   ffxDir = getFFXdir(subLabel, opt);
 
+  assertEqual(ffxDir, expectedOutput);
   assertEqual(exist(expectedOutput, 'dir'), 7);
+
+  rmdir(ffxDir, 's');
 
 end
 
@@ -39,5 +75,7 @@ function test_getFFXdir_user_specified()
 
   assertEqual(ffxDir, expectedOutput);
   assertEqual(exist(expectedOutput, 'dir'), 7);
+
+  rmdir(ffxDir, 's');
 
 end

--- a/tests/tests_bids_model/test_getFFXdir.m
+++ b/tests/tests_bids_model/test_getFFXdir.m
@@ -71,7 +71,7 @@ function test_getFFXdir_user_specified()
   ffxDir = getFFXdir(subLabel, opt);
 
   expectedOutput = fullfile(getDummyDataDir('stats'), 'sub-02', ...
-                            'task-vismotion_space-individual_FWHM-6_desc-globalSignal');
+                            'task-vismotion_space-individual_FWHM-6_node-globalSignal');
 
   assertEqual(ffxDir, expectedOutput);
   assertEqual(exist(expectedOutput, 'dir'), 7);

--- a/tests/tests_bids_model/test_getRFXdir.m
+++ b/tests/tests_bids_model/test_getRFXdir.m
@@ -8,6 +8,40 @@ function test_suite = test_getRFXdir %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_getRFXdir_ignored_desc()
+
+  opt = setOptions('vislocalizer', '', 'pipelineType', 'stats');
+  opt.fwhm.func = 0;
+  opt.fwhm.contrast = 0;
+  opt.space = 'IXI549Space';
+
+  omitList = {'dataset'; ...
+              'dataset level'; ...
+              ' dataset level '; ...
+              '-dataset-level-'; ...
+              '_dataset_level_'};
+  omitList = cat(1, omitList, upper(omitList));
+
+  for i = 1:numel(omitList)
+
+    opt.model.bm.Nodes{3}.Name = omitList{i};
+    opt.model.bm.Edges{2}.Destination = omitList{i};
+
+    ffxDir = getRFXdir(opt);
+
+    expectedOutput = fullfile(getDummyDataDir('stats'), ...
+                              'derivatives', 'cpp_spm-groupStats', ...
+                              'sub-ALL_task-vislocalizer_space-IXI549Space_FWHM-0_conFWHM-0');
+
+    assertEqual(ffxDir, expectedOutput);
+    assertEqual(exist(expectedOutput, 'dir'), 7);
+
+    cleanUp(fullfile(getDummyDataDir('stats'), 'derivatives', 'cpp_spm-groupStats'));
+
+  end
+
+end
+
 function test_getRFXdir_withinGroup()
 
   opt = setOptions('vislocalizer', '', 'pipelineType', 'stats');


### PR DESCRIPTION
- use a `node` entity instead of a `desc` one for run level stats folder when using a user specified "description"
- ignore more Node.Name than just `run_level` or `dataset_level` - fixes #647 

The path will be a default one if the node name is similar to one of those (regexp actually used to remove spaces, dashes, underscores...):

```matlab
  omitList = {'run'; ...
              'run level'; ...
              ' run level '; ...
              '-run-level-'; ...
              '_run_level_'};

  omitList = {'dataset'; ...
              'dataset level'; ...
              ' dataset level '; ...
              '-dataset-level-'; ...
              '_dataset_level_'};
```
