### PR TITLE
[FIX] label actiation: csv results file witrh no significant voxels are ignored with a warning

### DIFF
--- a/src/utils/labelActivations.m
+++ b/src/utils/labelActivations.m
@@ -13,7 +13,7 @@ function tsvFile = labelActivations(varargin)
   %
   % (C) Copyright 2022 CPP_SPM developers
 
-  % The code goes below
+  tsvFile = [];
 
   args = inputParser;
 
@@ -51,6 +51,13 @@ function tsvFile = labelActivations(varargin)
   label = {'x', 'y', 'z'};
   for i = 1:numel(coordinates)
     newCSV.(label{i}) = str2double(CSV.(headers{coordinates(i)})(2:end));
+  end
+
+  if isempty(newCSV.x)
+    verbosity = 2;
+    msg = sprintf('no significant voxels in file:\n\t%s', pathToPrint(csvFile));
+    errorHandling(mfilename(), 'noSignificantVoxel', msg, true, verbosity);
+    return
   end
 
   %% add MNI label

--- a/tests/dummyData/tsv_files/bug662_results_table.csv
+++ b/tests/dummyData/tsv_files/bug662_results_table.csv
@@ -1,0 +1,2 @@
+set,set,cluster,cluster,cluster,cluster,peak,peak,peak,peak,peak,,,
+p,c,p(FWE-corr),p(FDR-corr),equivk,p(unc),p(FWE-corr),p(FDR-corr),T,equivZ,p(unc),x,y,z {mm}

--- a/tests/tests_unit/test_labelActivations.m
+++ b/tests/tests_unit/test_labelActivations.m
@@ -23,3 +23,11 @@ function test_labelActivations_basic()
   assertEqual(content, expectedContent);
 
 end
+
+function test_labelActivations_bug_662()
+
+  csvFile = fullfile(getDummyDataDir(), 'tsv_files', 'bug662_results_table.csv');
+
+  assertWarning(@() labelActivations(csvFile), 'labelActivations:noSignificantVoxel');
+
+end


### PR DESCRIPTION
fix bug #662 

csv results file when there is no significant voxels are ignored with a warning